### PR TITLE
fix: TG-884 verify using HS256 token for keycloak 7

### DIFF
--- a/src/main/java/in/ekstep/am/jwt/CryptoUtil.java
+++ b/src/main/java/in/ekstep/am/jwt/CryptoUtil.java
@@ -21,6 +21,18 @@ public class CryptoUtil {
         return signature;
     }
 
+    public static byte[] generateHMAC(String payLoad, byte[] secretKey, String algorithm) {
+        Mac mac;
+        byte[] signature;
+        try {
+            mac = Mac.getInstance(algorithm);
+            mac.init(new SecretKeySpec(secretKey, algorithm));
+            signature = mac.doFinal(payLoad.getBytes(US_ASCII));
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            return null;
+        }
+        return signature;
+    }
 
     public static byte[] generateRSASign(String payLoad, PrivateKey key, String algorithm) {
         Signature sign;

--- a/src/main/java/in/ekstep/am/jwt/JWTUtil.java
+++ b/src/main/java/in/ekstep/am/jwt/JWTUtil.java
@@ -15,6 +15,12 @@ public class JWTUtil {
         return payLoad + SEPARATOR + signature;
     }
 
+    public static String createHS256Token(String payLoad, byte[] secretKey) {
+        JWTokenType tokenType = JWTokenType.HS256;
+        String signature = encodeToBase64Uri(CryptoUtil.generateHMAC(payLoad, secretKey, tokenType.getAlgorithmName()));
+        return payLoad + SEPARATOR + signature;
+    }
+
     public static String createRS256Token(String key, PrivateKey privateKey, Map<String, String> headerOptions) {
         JWTokenType tokenType = JWTokenType.RS256;
         String payLoad = createHeader(tokenType, headerOptions) + SEPARATOR + createClaims(key);

--- a/src/main/java/in/ekstep/am/jwt/KeyManager.java
+++ b/src/main/java/in/ekstep/am/jwt/KeyManager.java
@@ -60,7 +60,9 @@ public class KeyManager {
         String basePath = environment.getProperty("refresh.token.public.basepath");
         String keyPrefix = environment.getProperty("refresh.token.public.keyprefix");
         String keyId = environment.getProperty("refresh.token.kid");
+        String secretKey = environment.getProperty("refresh.token.secret.key");
         keyMetadata.put("refresh.token.kid", keyId);
+        keyMetadata.put("refresh.token.secret.key", secretKey);
         keyMetadata.put("refresh.token.domain", environment.getProperty("refresh.token.domain"));
         keyMetadata.put("access.token.validity", environment.getProperty("access.token.validity"));
         keyMetadata.put("refresh.token.offline.validity", environment.getProperty("refresh.token.offline.validity"));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,13 +44,14 @@ endpoints.health.sensitive=false
 endpoints.metrics.id=metrics
 endpoints.metrics.sensitive=false
 
-# These define the domain, public key and KID value of Keycloak token along with the validity of access and refresh tokens
+# These define the domain, public key, secret key and KID value of Keycloak token along with the validity of access and refresh tokens
 # Using the below values, the keycloak refresh token is validated and a new access token is issued using one of the access keys
 # As of now, the same refresh token is sent back to client and only access token is generated and signed by this service
 refresh.token.public.basepath=/tmp/
 refresh.token.public.keyprefix=refresh_token_public_key
 refresh.token.preload=false
 refresh.token.kid=KID_VALUE
+refresh.token.secret.key=SECRET_KEY_VALUE
 refresh.token.domain=https://example.org/auth/realms/sunbird
 access.token.validity=43200
 refresh.token.offline.validity=2592000


### PR DESCRIPTION
- Since keycloak 4.5.0, refresh tokens are signed using HS256 algorithm
- Reference https://issues.redhat.com/browse/KEYCLOAK-4622
- Devops code changes - https://github.com/project-sunbird/sunbird-devops/pull/2377