### PR TITLE
feat: TG-1047 updated code to support non offline tokens

### DIFF
--- a/src/main/java/in/ekstep/am/step/TokenSignStep.java
+++ b/src/main/java/in/ekstep/am/step/TokenSignStep.java
@@ -131,15 +131,15 @@ public class TokenSignStep implements TokenStep {
         long exp;
 
         if(bodyData.get("typ").equals("Offline")) {
-            if(tokenValidTill < (tokenValidity + currentTime)) {
-                exp = tokenValidTill;
+            if(tokenValidTill > (tokenValidity + currentTime)) {
+                exp = currentTime + tokenValidity;
             }
             else {
-                exp = currentTime + tokenValidity;;
+                exp = tokenValidTill;
             }
         }
         else {
-            if((currentTime + tokenValidity) < tokenExpiry) {
+            if(tokenExpiry > (currentTime + tokenValidity)) {
                 exp = currentTime + tokenValidity;
             }
             else {

--- a/src/main/java/in/ekstep/am/step/TokenSignStep.java
+++ b/src/main/java/in/ekstep/am/step/TokenSignStep.java
@@ -6,7 +6,6 @@ import in.ekstep.am.builder.TokenSignResponseBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
@@ -98,7 +97,6 @@ public class TokenSignStep implements TokenStep {
         tokenWasIssuedAt = iat.longValueExact();
         tokenExpiry = exp.longValueExact();
 
-
         if(bodyData.get("typ").equals("Offline")) {
             offlineTokenValidity = Long.parseLong(keyManager.getValueFromKeyMetaData("refresh.token.offline.validity"));
             tokenValidTill = tokenWasIssuedAt + offlineTokenValidity;
@@ -119,7 +117,6 @@ public class TokenSignStep implements TokenStep {
                 return false;
             }
         }
-
         return true;
     }
 
@@ -131,7 +128,7 @@ public class TokenSignStep implements TokenStep {
         long exp;
 
         if(bodyData.get("typ").equals("Offline")) {
-            if(tokenValidTill > (tokenValidity + currentTime)) {
+            if(tokenValidTill > (currentTime + tokenValidity)) {
                 exp = currentTime + tokenValidity;
             }
             else {
@@ -160,6 +157,7 @@ public class TokenSignStep implements TokenStep {
         tokenSignResponseBuilder.setAccessToken(JWTUtil.createRS256Token(header, body, keyData.getPrivateKey()));
         tokenSignResponseBuilder.setRefreshToken(currentToken);
         tokenSignResponseBuilder.setExpiresIn(exp - currentTime);
+
         if(bodyData.get("typ").equals("Offline")) {
             tokenSignResponseBuilder.setRefreshExpiresIn(0);
         }


### PR DESCRIPTION
- Code update to handle non offline tokens (tokens which have typ as `typ: Refresh`)
- Now we correctly set the access token validity to the lower value of:
  - Access token validity (12 hours env configuration) 
  - OR
  - Expiry of the refresh token
- Updated casting to use `BigDecimal` instead of `Double`
- Reponse message will also now show the time remaining for access and refresh token expiry


##### `typ: Refresh`
```
"result": {
        "access_token": "XXX",
        "expires_in": 43200,
        "refresh_expires_in": 85193,
        "refresh_token": "YYY"
    }
}
```
##### `typ: Offline`
```
"result": {
        "access_token": "XXX",
        "expires_in": 9826,
        "refresh_expires_in": 0,
        "refresh_token": "YYY"
    }
}
```