### PR TITLE
fix: TG-1053 change embedded server from jetty to tomcat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ configurations {
 dependencies {
   compile('org.springframework.boot:spring-boot-starter')
   compile("org.springframework.boot:spring-boot-starter-web")
-  compile("org.springframework.boot:spring-boot-starter-jetty:1.5.2.RELEASE")
+  compile('org.apache.tomcat.embed:tomcat-embed-jasper:8.0.47')
   compile("com.google.code.gson:gson:2.8.6")
   compile("com.squareup.okhttp3:okhttp:3.6.0")
   compile("org.hibernate:hibernate-validator")


### PR DESCRIPTION
- We have noticed that the load distribution across pod, from kong, is not consistent using jetty as the embedded server since the connections aren't being closed by jetty
- Using tomcat we have tested load distribution works very well and also there are no drop in TPS / increase in latencies