### PR TITLE
Issue #SBCOSS-00: Create Github actions to publish docker image to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: Build and Deploy
+
+on:
+    push:
+       tags:
+         - '*'
+
+jobs:
+  ghcr-build-and-deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      REGISTRY: ghcr.io
+
+    steps:
+
+      - name: Set up JDK 8 (Temurin)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+    
+      - name: Build with Gradle
+        run: |
+            chmod +x ./gradlew
+            ./gradlew clean build -x test
+      - name: Extract image tag details
+        id: image_vars
+        run: |
+          REPO_LOWER=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          TAG_LOWER=$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME=${{ env.REGISTRY }}/${REPO_LOWER}
+          IMAGE_TAG=${TAG_LOWER}_${SHORT_SHA}_${GITHUB_RUN_NUMBER}
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+      - name: Log in to GitHub Container Registry (GHCR)
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image to GHCR
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          build-args: |
+            JAR_FILE=./build/libs/*.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,14 @@ jobs:
 
     steps:
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Set up JDK 8 (Temurin)
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
     
       - name: Build with Gradle
         run: |


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to the `sunbird-apimanager-util` repository.

**Build and Deploy (`build.yml`):**  
Triggers when a Git tag is pushed.  
Builds the project, packages the artifact, builds a Docker image, and pushes it to GitHub Container Registry (GHCR).

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Create a GitHub Actions workflow to build and publish a Docker image to GitHub Container Registry (GHCR) on each push to a tagged commit.

### Why are these changes being made?
This change automates the build process for Docker images and their deployment to a container registry, streamlining the development and deployment pipeline by ensuring that every tagged version of the code is consistently built and available as a Docker image in GHCR. This approach uses GitHub's native services for seamless integration, simplifies credential management through GitHub secrets, and aligns with modern CI/CD practices.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->