### PR TITLE
security: Patch critical and high vulnerabilities in dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,9 @@ dependencies {
   compile('org.springframework.boot:spring-boot-starter')
   compile("org.springframework.boot:spring-boot-starter-web")
   compile('org.apache.tomcat.embed:tomcat-embed-jasper:8.0.47')
-  compile("com.google.code.gson:gson:2.8.6")
-  compile("com.squareup.okhttp3:okhttp:3.6.0")
-  compile("org.hibernate:hibernate-validator")
+  compile("com.google.code.gson:gson:2.8.9")
+  compile("com.squareup.okhttp3:okhttp:4.9.2")
+  compile("org.hibernate:hibernate-validator:5.4.3.Final")
   compile("org.springframework.boot:spring-boot-starter-actuator")
   compile ('com.ryantenney.metrics:metrics-spring:3.1.3') {
     exclude group: 'com.codahale.metrics'
@@ -53,12 +53,13 @@ dependencies {
   compile("io.dropwizard.metrics:metrics-annotation")
   compile("org.apache.commons:commons-collections4:4.4")
 
-  compile('ch.qos.logback:logback-classic:1.2.12')
-  compile('ch.qos.logback:logback-core:1.2.12')
+  compile('ch.qos.logback:logback-classic:1.2.13')
+  compile('ch.qos.logback:logback-core:1.2.13')
 
-  compile("com.fasterxml.jackson.core:jackson-databind:2.9.10.8")
-  compile("com.fasterxml.jackson.core:jackson-core:2.9.10")
-  compile("com.fasterxml.jackson.core:jackson-annotations:2.9.10")
+  compile("com.fasterxml.jackson.core:jackson-databind:2.15.0")
+  compile("com.fasterxml.jackson.core:jackson-core:2.15.0")
+  compile("com.fasterxml.jackson.core:jackson-annotations:2.15.0")
+  compile("org.yaml:snakeyaml:1.32")
 
   testCompile('io.rest-assured:rest-assured:3.0.2')
   testCompile('org.springframework.boot:spring-boot-starter-test')


### PR DESCRIPTION
## Description
This PR addresses several high and critical security vulnerabilities in `adminutil.jar` by upgrading key third-party libraries (Jackson, Gson, OkHttp, Logback, and SnakeYAML).

### Key Changes:
- **Jackson (2.15.0)**: Fixed RCE/deserialization vulnerabilities.
- **Gson (2.8.9)/OkHttp (4.9.2)**: Updated to latest secure versions.
- **Logback (1.2.13)/Hibernate Validator (5.4.3.Final)**: Addressed logging and validation CVEs.
- **SnakeYAML (1.32)**: Pinned to fix multiple DoS/RCE vulnerabilities including CVE-2022-1471.
